### PR TITLE
Fix SRC description to indicate that it can be a file or a directory

### DIFF
--- a/lib/mortar/command.rb
+++ b/lib/mortar/command.rb
@@ -12,7 +12,7 @@ module Mortar
     banner "mortar - Kubernetes manifest shooter"
 
     parameter "NAME", "deployment name"
-    parameter "SRC", "source folder"
+    parameter "SRC", "source file or directory"
 
     option ["--var"], "VAR", "set template variables", multivalued: true
     option ["-d", "--debug"], :flag, "debug"


### PR DESCRIPTION
The resource helper can also load a single file instead of a directory.

https://github.com/kontena/mortar/blob/master/lib/mortar/resource_helper.rb#L22-L27 