### PR TITLE
Add kube connection settings as options

### DIFF
--- a/lib/mortar/command.rb
+++ b/lib/mortar/command.rb
@@ -31,7 +31,7 @@ module Mortar
       begin
         Base64.strict_decode64(token)
       rescue ArgumentError
-        signal_usage_error "KUBE_TOKEN env doesn't seem to be base64 encoded!"
+        signal_usage_error "kube token doesn't seem to be base64 encoded!"
       end
     end
 


### PR DESCRIPTION
Kube connection settings can now be defined also as command line options.

```
    --kube-config PATH            Kubernetes config path (default: $KUBECONFIG)
    --kube-server ADDRESS         Kubernetes API server address (default: $KUBE_SERVER)
    --kube-ca DATA                Kubernetes certificate authority data (default: $KUBE_CA)
    --kube-token TOKEN            Kubernetes access token (Base64 encoded) (default: $KUBE_TOKEN)
```

