### PR TITLE
Drop TTY::Prompt dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,6 @@ PATH
       k8s-client (~> 0.3)
       pastel (~> 0.7.2)
       rouge (~> 3.2)
-      tty-prompt (~> 0.17.0)
 
 GEM
   remote: https://rubygems.org/
@@ -43,14 +42,12 @@ GEM
       dry-logic (~> 0.4, >= 0.4.2)
     equatable (0.5.0)
     excon (0.62.0)
-    hitimes (1.3.0)
     ice_nine (0.11.2)
     k8s-client (0.3.4)
       deep_merge (~> 1.2.1)
       dry-struct (~> 0.5.0)
       excon (~> 0.62.0)
       recursive-open-struct (~> 1.1.0)
-    necromancer (0.4.0)
     pastel (0.7.2)
       equatable (~> 0.5.0)
       tty-color (~> 0.4.0)
@@ -70,22 +67,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    timers (4.1.2)
-      hitimes
     tty-color (0.4.3)
-    tty-cursor (0.6.0)
-    tty-prompt (0.17.0)
-      necromancer (~> 0.4.0)
-      pastel (~> 0.7.0)
-      timers (~> 4.0)
-      tty-cursor (~> 0.6.0)
-      tty-reader (~> 0.4.0)
-    tty-reader (0.4.0)
-      tty-cursor (~> 0.6.0)
-      tty-screen (~> 0.6.4)
-      wisper (~> 2.0.0)
-    tty-screen (0.6.5)
-    wisper (2.0.0)
 
 PLATFORMS
   ruby

--- a/kontena-mortar.gemspec
+++ b/kontena-mortar.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "k8s-client", "~> 0.3"
   spec.add_runtime_dependency "rouge", "~> 3.2"
   spec.add_runtime_dependency "deep_merge", "~> 1.2"
-  spec.add_runtime_dependency "tty-prompt", "~> 0.17.0"
   spec.add_runtime_dependency "pastel", "~> 0.7.2"
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/mortar.rb
+++ b/lib/mortar.rb
@@ -9,9 +9,6 @@ autoload :ERB, "erb"
 autoload :Rouge, "rouge"
 autoload :RecursiveOpenStruct, "recursive-open-struct"
 autoload :Pastel, "pastel"
-module TTY
-  autoload :Prompt, "tty-prompt"
-end
 
 require "extensions/recursive_open_struct/each"
 

--- a/lib/mortar/mixins/tty_helper.rb
+++ b/lib/mortar/mixins/tty_helper.rb
@@ -1,10 +1,5 @@
 module Mortar
   module TTYHelper
-    # @return [TTY::Prompt]
-    def prompt
-      @prompt ||= TTY::Prompt.new
-    end
-
     # @return [Pastel]
     def pastel
       @pastel ||= Pastel.new

--- a/lib/mortar/yank_command.rb
+++ b/lib/mortar/yank_command.rb
@@ -13,8 +13,17 @@ module Mortar
 
     def execute
       unless force?
-        unless prompt.ask("enter '#{pastel.cyan(name)}' to confirm yank:") == name
-          signal_error("confirmation did not match #{pastel.cyan(name)}.")
+        if $stdin.tty?
+          print "enter '#{pastel.cyan(name)}' to confirm yank: "
+          begin
+            signal_error("confirmation did not match #{pastel.cyan(name)}.") unless $stdin.gets.chomp == name
+          rescue Interrupt
+            puts
+            puts "Canceled"
+            return
+          end
+        else
+          signal_usage_error '--force required when running in a non-interactive mode'
         end
       end
 
@@ -26,8 +35,6 @@ module Mortar
       ).prune(client, keep_resources: false)
 
       puts "yanked #{pastel.cyan(name)} successfully!" if $stdout.tty?
-
-    rescue TTY::Reader::InputInterrupt
     end
   end
 end


### PR DESCRIPTION
Removes the TTY::Prompt dependency by replacing the confirmation prompt with a simple self made one, resulting in approx. 9 removed sub-dependencies.
