### PR TITLE
Fix invalid erb trim mode warning on ruby 2.6+

### DIFF
--- a/lib/mortar/yaml_file.rb
+++ b/lib/mortar/yaml_file.rb
@@ -54,7 +54,7 @@ module Mortar
 
     def read(variables = {})
       Namespace.new(variables).with_binding do |ns_binding|
-        ERB.new(@content, nil, '%<>-').tap { |e| e.location = [@filename, nil] }.result(ns_binding)
+        ERB.new(@content, nil, '-').tap { |e| e.location = [@filename, nil] }.result(ns_binding)
       end
     rescue StandardError, ScriptError => e
       raise ParseError, "#{e.class.name} : #{e.message} (#{e.backtrace.first.gsub(/:in `with_binding'/, '')})"


### PR DESCRIPTION
Fixes #114 

Just like https://github.com/kontena/pharos-cluster/pull/947
